### PR TITLE
Replaced ".gifv" with ".mp4" in video cache download.

### DIFF
--- a/src/main/java/com/kenny/openimgur/classes/VideoCache.java
+++ b/src/main/java/com/kenny/openimgur/classes/VideoCache.java
@@ -147,7 +147,8 @@ public class VideoCache {
         protected Object doInBackground(File... file) {
             InputStream in = null;
             BufferedOutputStream buffer = null;
-            LogUtil.v(TAG, "Downlong video from " + mUrl);
+            mUrl = mUrl.replace(".gif", ".mp4");
+            LogUtil.v(TAG, "Download video from " + mUrl);
 
             try {
                 in = new URL(mUrl).openStream();

--- a/src/main/java/com/kenny/openimgur/classes/VideoCache.java
+++ b/src/main/java/com/kenny/openimgur/classes/VideoCache.java
@@ -147,7 +147,7 @@ public class VideoCache {
         protected Object doInBackground(File... file) {
             InputStream in = null;
             BufferedOutputStream buffer = null;
-            mUrl = mUrl.replace(".gif", ".mp4");
+            mUrl = mUrl.replace(".gifv", ".mp4");
             LogUtil.v(TAG, "Download video from " + mUrl);
 
             try {

--- a/src/main/java/com/kenny/openimgur/fragments/CommentPopupFragment.java
+++ b/src/main/java/com/kenny/openimgur/fragments/CommentPopupFragment.java
@@ -151,7 +151,7 @@ public class CommentPopupFragment extends DialogFragment implements View.OnClick
                     client.doWork(ImgurBusEvent.EventType.COMMENT_POSTED, null, new FormEncodingBuilder().add("comment", comment).build());
                     dismiss();
                 } else {
-                    // Shake the edit text to show that they have not enetered any text
+                    // Shake the edit text to show that they have not entered any text
                     ObjectAnimator.ofFloat(mComment, "translationX", 0, 25, -25, 25, -25, 15, -15, 6, -6, 0).setDuration(750L).start();
                 }
                 break;


### PR DESCRIPTION
The problem was that VideoCache tried to download from the ".gifv" url. That file downloaded was invalid and unplayable by VideoView. Changing the url to ".mp4" fixed this error.