### PR TITLE
Fix for issue #60

### DIFF
--- a/src/main/res/layout/login_view.xml
+++ b/src/main/res/layout/login_view.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<WebView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/loginWebView"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <WebView
+        android:id="@+id/loginWebView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</FrameLayout>


### PR DESCRIPTION
Tried to avoid layout complexity, but in the end, adding a parent to the webview and setting its fitSystemWindow to true was a solution that didn't regress any other part of the ProfileActivity. Plus, FrameLayouts are the most lightweight viewgroups so I do not think it will be an issue. 