### PR TITLE
Fix comment dialog edittext on < 5.0

### DIFF
--- a/src/main/java/com/kenny/openimgur/fragments/CommentPopupFragment.java
+++ b/src/main/java/com/kenny/openimgur/fragments/CommentPopupFragment.java
@@ -87,7 +87,7 @@ public class CommentPopupFragment extends DialogFragment implements View.OnClick
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         int style = OpenImgurApp.getInstance(getActivity()).getImgurTheme().isDarkTheme ?
-                android.R.style.Theme_DeviceDefault_Dialog : android.R.style.Theme_DeviceDefault_Light_Dialog;
+                R.style.Theme_AppCompat_Dialog : R.style.Theme_AppCompat_Light_Dialog;
         setStyle(DialogFragment.STYLE_NO_TITLE, style);
     }
 


### PR DESCRIPTION
The add comment dialog was getting Holo attributes since it was using the devices theme, such as EditTexts appearing with the Holo Blue style. Fixed this to use AppCompat Dialog themes, so that the EditText tinting is performed making it look more like a material dialog.